### PR TITLE
Update MSButtonNode

### DIFF
--- a/MSButtonNode.swift
+++ b/MSButtonNode.swift
@@ -9,7 +9,7 @@
 import SpriteKit
 
 enum MSButtonNodeState {
-    case MSButtonNodeStateActive, MSButtonNodeStateSelected, MSButtonNodeStateHidden
+    case active, selected, hidden
 }
 
 class MSButtonNode: SKSpriteNode {
@@ -18,21 +18,21 @@ class MSButtonNode: SKSpriteNode {
     var selectedHandler: () -> Void = { print("No button action set") }
     
     /* Button state management */
-    var state: MSButtonNodeState = .MSButtonNodeStateActive {
+    var state: MSButtonNodeState = .active {
         didSet {
             switch state {
-            case .MSButtonNodeStateActive:
+            case .active:
                 /* Enable touch */
                 self.isUserInteractionEnabled = true
                 
                 /* Visible */
                 self.alpha = 1
                 break
-            case .MSButtonNodeStateSelected:
+            case .selected:
                 /* Semi transparent */
                 self.alpha = 0.7
                 break
-            case .MSButtonNodeStateHidden:
+            case .hidden:
                 /* Disable touch */
                 self.isUserInteractionEnabled = false
                 
@@ -55,12 +55,12 @@ class MSButtonNode: SKSpriteNode {
     
     // MARK: - Touch handling
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        state = .MSButtonNodeStateSelected
+        state = .selected
     }
     
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         selectedHandler()
-        state = .MSButtonNodeStateActive
+        state = .active
     }
     
 }


### PR DESCRIPTION
Updated the enum styling to properly reflect accepted Swift styling. The redundant name of the enum in the cases was recommended removed during the Swift 2 -> Swift 3 transition.